### PR TITLE
Restart button additions

### DIFF
--- a/speed-typer/source_ui/typingWindow.ui
+++ b/speed-typer/source_ui/typingWindow.ui
@@ -318,10 +318,40 @@ QFrame[frameShape=&quot;4&quot;] {
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Preferred</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>30</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QLabel" name="labelTime">
+       <property name="text">
+        <string>1000</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="labelUnit">
+       <property name="text">
+        <string>s</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_7">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
        <property name="sizeHint" stdset="0">
         <size>
          <width>80</width>
-         <height>40</height>
+         <height>20</height>
         </size>
        </property>
       </spacer>

--- a/speed-typer/source_ui/typing_window.py
+++ b/speed-typer/source_ui/typing_window.py
@@ -139,8 +139,16 @@ class Ui_typingWindow(object):
         self.buttonNewText.setFocusPolicy(QtCore.Qt.NoFocus)
         self.buttonNewText.setObjectName("buttonNewText")
         self.horizontalLayoutButtons.addWidget(self.buttonNewText)
-        spacerItem7 = QtWidgets.QSpacerItem(80, 40, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
+        spacerItem7 = QtWidgets.QSpacerItem(30, 40, QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Minimum)
         self.horizontalLayoutButtons.addItem(spacerItem7)
+        self.labelTime = QtWidgets.QLabel(typingWindow)
+        self.labelTime.setObjectName("labelTime")
+        self.horizontalLayoutButtons.addWidget(self.labelTime)
+        self.labelUnit = QtWidgets.QLabel(typingWindow)
+        self.labelUnit.setObjectName("labelUnit")
+        self.horizontalLayoutButtons.addWidget(self.labelUnit)
+        spacerItem8 = QtWidgets.QSpacerItem(80, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
+        self.horizontalLayoutButtons.addItem(spacerItem8)
         self.verticalLayout.addLayout(self.horizontalLayoutButtons)
 
         self.retranslateUi(typingWindow)
@@ -154,6 +162,8 @@ class Ui_typingWindow(object):
         self.buttonMainMenu.setText(_translate("typingWindow", "Main Menu"))
         self.buttonRestart.setText(_translate("typingWindow", "Restart"))
         self.buttonNewText.setText(_translate("typingWindow", "New Text"))
+        self.labelTime.setText(_translate("typingWindow", "1000"))
+        self.labelUnit.setText(_translate("typingWindow", "s"))
 
 
 if __name__ == "__main__":

--- a/speed-typer/type_test.py
+++ b/speed-typer/type_test.py
@@ -22,13 +22,16 @@ class TypingWindow(QtWidgets.QWidget, typing_window.Ui_typingWindow):
         self.buttonNewText.clicked.connect(self.on_clicked_new)
         self.buttonRestart.clicked.connect(self.on_clicked_restart)
 
-        # timer
-        self.start_time = None
+        # time and timer
+        self.timer = QtCore.QTimer(self)
+        self.timer.timeout.connect(self.update_time)
+        self.timer.setInterval(100)
+        self.reset_time()
 
         # Object to handle saving and updating of highscore values
         self.highscore = highscores.Highscores()
 
-        self.key_sound = False
+        self.key_sound = None
 
     # Helper Methods
     def set_mode(self, mode):
@@ -95,6 +98,18 @@ class TypingWindow(QtWidgets.QWidget, typing_window.Ui_typingWindow):
 
         return rich_text
 
+    def update_time(self):
+        """Updates the displayed time on self.labelTime in seconds since self.start_time."""
+
+        self.labelTime.setText(str(int(perf_counter() - self.start_time)))
+
+    def reset_time(self):
+        """Resets self.timer, self.start_time and self.labelTime."""
+
+        self.start_time = None
+        self.timer.stop()
+        self.labelTime.setText("0")
+
     def make_results_window(self):
         self.results_window = results.ResultsWindow()
 
@@ -123,8 +138,8 @@ class TypingWindow(QtWidgets.QWidget, typing_window.Ui_typingWindow):
 
     # Button Methods
     def on_clicked_restart(self):
-        self.start_time = None
         self.lineInput.clear()
+        self.reset_time()
 
     def on_clicked_new(self):
         self.on_clicked_restart()
@@ -160,8 +175,9 @@ class TypingWindow(QtWidgets.QWidget, typing_window.Ui_typingWindow):
         if len(input_text) > len(self.text):
             return None
 
-        # Start timer if it has not yet been started
+        # Update displayed time or start timer
         if not self.start_time:
+            self.timer.start()
             self.start_time = perf_counter()
 
         # Try to play key sound effect, if it exists

--- a/speed-typer/type_test.py
+++ b/speed-typer/type_test.py
@@ -20,6 +20,7 @@ class TypingWindow(QtWidgets.QWidget, typing_window.Ui_typingWindow):
 
         self.lineInput.textChanged.connect(self.on_input_text_changed)
         self.buttonNewText.clicked.connect(self.on_clicked_new)
+        self.buttonRestart.clicked.connect(self.on_clicked_restart)
 
         # timer
         self.start_time = None


### PR DESCRIPTION
In relation to #15 

Added a timer at the bottom right of the typing window which displays time in seconds since the user started typing, which makes it obvious when restart is clicked that the timer is reset.

Also connected the restart button to it's appropriate function (bugfix, should have been connected already)