### PR TITLE
Use single highscore obj

### DIFF
--- a/speed-typer/main.py
+++ b/speed-typer/main.py
@@ -4,7 +4,6 @@ from PyQt5 import QtCore, QtWidgets
 from PyQt5.QtMultimedia import QSoundEffect
 from PyQt5.QtGui import QIcon
 from pathlib import Path
-from typing import Any
 
 from source_ui import main_window
 from type_test import highscores, settings, statistics, type_test

--- a/speed-typer/main.py
+++ b/speed-typer/main.py
@@ -204,7 +204,6 @@ class MainWindow(QtWidgets.QWidget, main_window.Ui_mainWindow):
         self.stats_window.buttonResetAll.clicked.connect(self.on_clicked_reset_all)
 
     def update_highscores(self) -> None:
-        self.highscore._load_data()
         self.today_wpm, self.all_time_wpm = self.highscore.get_wpm()
 
         self.labelTodayScore.setText(f"{self.today_wpm} WPM")

--- a/speed-typer/main.py
+++ b/speed-typer/main.py
@@ -142,7 +142,7 @@ class MainWindow(QtWidgets.QWidget, main_window.Ui_mainWindow):
 
     # Helper Methods
     def make_mode_window(self, mode: str) -> None:
-        self.mode_window = type_test.TypingWindow()
+        self.mode_window = type_test.TypingWindow(self.highscore)
         self.mode_window.set_mode(mode)
 
         self.mode_window.setWindowIcon(self.ICON)

--- a/speed-typer/type_test/type_test.py
+++ b/speed-typer/type_test/type_test.py
@@ -37,7 +37,7 @@ class TypingWindow(QtWidgets.QWidget, typing_window.Ui_typingWindow):
         self.highscore = highscore_obj
 
         # Defaults
-        self.key_sound = None
+        self.key_sound = QSoundEffect()
         self.set_colours(DEFAULT_COLOURS)
 
     # Public Methods
@@ -220,10 +220,7 @@ class TypingWindow(QtWidgets.QWidget, typing_window.Ui_typingWindow):
             self.start_time = perf_counter()
 
         # Try to play key sound effect, if it exists
-        try:
-            self.key_sound.play()
-        except AttributeError:
-            pass
+        self.key_sound.play()
 
         # Set label text to rich text so typed characters are highlighted
         # based on whether they match self.text

--- a/speed-typer/type_test/type_test.py
+++ b/speed-typer/type_test/type_test.py
@@ -16,7 +16,7 @@ _TRANSLATE_RESULT = {
 
 
 class TypingWindow(QtWidgets.QWidget, typing_window.Ui_typingWindow):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, highscore_obj: highscores.Highscores, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
         # Multiple inheritance allows us to have the ui and window together so
@@ -34,7 +34,7 @@ class TypingWindow(QtWidgets.QWidget, typing_window.Ui_typingWindow):
         self._reset_time()
 
         # Object to handle saving and updating of highscore values
-        self.highscore = highscores.Highscores()
+        self.highscore = highscore_obj
 
         # Defaults
         self.key_sound = None
@@ -264,7 +264,7 @@ class TypingWindow(QtWidgets.QWidget, typing_window.Ui_typingWindow):
 if __name__ == "__main__":
     app = QtWidgets.QApplication([])
 
-    window = TypingWindow()
+    window = TypingWindow(highscores.Highscores())
     window.show()
 
     app.exec_()


### PR DESCRIPTION
In relation to #40 

Modified the type_test.py so that the TypingWindow class must be passed a highscore object to handle the highscores, allowing the main window to simply pass its own highscore object so that they can share the same one.

Also made minor adjustment to handling of the QSoundEffect object in the TypingWindow class so that a try except block is unecessary and so mypy does not raise errors